### PR TITLE
Fe onboarding pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ import Signup from './pages/SignUp/SignUp';
 import Dashboard from './pages/Dashboard/Dashboard';
 import Scheduler from './pages/Scheduler/Scheduler';
 import GoogleConnect from './components/GoogleConnect/GoogleConnect';
+import Onboarding from './pages/Onboarding/Onboarding';
 
 function App(): JSX.Element {
   return (
@@ -31,6 +32,9 @@ function App(): JSX.Element {
               </Route>
               <Route exact path="/:username/:time">
                 <Scheduler />
+              </Route>
+              <Route exact path="/onboarding">
+                <Onboarding />
               </Route>
               <Route path="*">
                 <Redirect to="/login" />

--- a/client/src/components/Onboarding/Availability/Availability.tsx
+++ b/client/src/components/Onboarding/Availability/Availability.tsx
@@ -1,7 +1,10 @@
 import React, { useState } from 'react';
-import { TextField, FormGroup, FormControlLabel, Checkbox } from '@material-ui/core';
+import { TextField, FormGroup, FormControlLabel, Checkbox, Box } from '@material-ui/core';
 import { Formik, FormikHelpers } from 'formik';
 import * as Yup from 'yup';
+import ProgressBar from '../ProgressBar';
+import useStyles from './useStyles';
+import AppLogo from '../../AppLogo';
 
 interface Props {
   handleSubmit: (
@@ -18,11 +21,12 @@ interface Props {
     }: FormikHelpers<{
       hours: string;
       days: string;
-    }>
+    }>,
   ) => void;
 }
 
 const Availability = ({ handleSubmit }: Props): JSX.Element => {
+  const classes = useStyles();
   const [hours, setHours] = useState({ start: '9:00', end: '17:00' });
   const [days, setDays] = useState({
     Sunday: false,
@@ -43,69 +47,80 @@ const Availability = ({ handleSubmit }: Props): JSX.Element => {
   function renderCheckBoxes(days: any) {
     return Object.keys(days).map((day) => {
       return (
-        <FormControlLabel
-          id={day + '-checkbox-field'}
-          key={day}
-          value={day}
-          control={<Checkbox checked={days[day]} onChange={handleChange} name={day} />}
-          label={day + 's'}
-          labelPlacement="bottom"
-        />
+        <Box key={day} className={classes.checkboxWrap}>
+          <FormControlLabel
+            id={day + '-checkbox-field'}
+            key={day}
+            value={day}
+            control={<Checkbox checked={days[day]} onChange={handleChange} name={day} />}
+            label={day + 's'}
+            labelPlacement="bottom"
+          />
+        </Box>
       );
     });
   }
 
   return (
-    <Formik
-     initialValues={{
-       hours: '',
-       days: '',
-     }}
-     isSubmitting={true}
-     isValidating={true}
-     validationSchema={Yup.object().shape({
-       hours: Yup.string().required('Please choose your hours.'),
-       days: Yup.object().required('Please select your days.'),
-     })}
-     onSubmit={handleSubmit}
-    >
-      {({handleSubmit, handleChange, touched, errors}) => (
-        <form onSubmit={handleSubmit}>
-          <div>
-        <div>Available Hours: </div>
-        <div>
-          <TextField
-            id="start-hours-field"
-            value={hours}
-            helperText={touched.hours ? errors.hours : ''}
-            error={ touched.hours && Boolean(errors.hours)}
-            variant="outlined"
-            type="time"
-            name="start"
-            onChange={handleChange}
-          />
-          <span>-</span>
-          <TextField
-            id="end-hours-field"
-            value={hours}
-            helperText={touched.hours ? errors.hours : ''}
-            error={ touched.hours && Boolean(errors.hours)}
-            variant="outlined"
-            type="time"
-            name="end"
-            onChange={handleChange}
-          />
-        </div>
-      </div>
+    <Box mt={6} className={classes.root}>
+      <AppLogo />
+      <Box className={classes.formWrapper}>
+        <ProgressBar progressText={'Set your availability'} progressValue={100} />
+        <Box className={classes.formItemsWrapper}>
+          <Formik
+            initialValues={{
+              hours: '',
+              days: '',
+            }}
+            isSubmitting={true}
+            isValidating={true}
+            validationSchema={Yup.object().shape({
+              hours: Yup.string().required('Please choose your hours.'),
+              days: Yup.object().required('Please select your days.'),
+            })}
+            onSubmit={handleSubmit}
+          >
+            {({ handleSubmit, handleChange, touched, errors }) => (
+              <form onSubmit={handleSubmit}>
+                <Box mx={7} mt={2} ml={6}>
+                  Available Hours:
+                </Box>
+                <Box mx={6} mt={1} ml={6} className={classes.formItem}>
+                  <TextField
+                    id="start-hours-field"
+                    value={hours}
+                    helperText={touched.hours ? errors.hours : ''}
+                    error={touched.hours && Boolean(errors.hours)}
+                    variant="outlined"
+                    type="time"
+                    name="start"
+                    onChange={handleChange}
+                  />
+                  <span>-</span>
+                  <TextField
+                    id="end-hours-field"
+                    value={hours}
+                    helperText={touched.hours ? errors.hours : ''}
+                    error={touched.hours && Boolean(errors.hours)}
+                    variant="outlined"
+                    type="time"
+                    name="end"
+                    onChange={handleChange}
+                  />
+                </Box>
+                <Box mx={6} mt={2} ml={6}>
+                  Available Days:
+                </Box>
+                <Box mx={2} mt={1} ml={6}>
+                  <FormGroup row>{renderCheckBoxes(days)}</FormGroup>
+                </Box>
+              </form>
+            )}
+          </Formik>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
 
-      <div>
-        <div>Available Days: </div>
-        <FormGroup row>{renderCheckBoxes(days)}</FormGroup>
-      </div>
-        </form>
-      )}
-      </Formik>
-    );
-      }
-
-  export default Availability;
+export default Availability;

--- a/client/src/components/Onboarding/Availability/useStyles.ts
+++ b/client/src/components/Onboarding/Availability/useStyles.ts
@@ -1,0 +1,41 @@
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles({
+  root: {
+    height: '100%',
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  formItemsWrapper: {
+    width: '100%',
+    height: '100%',
+    borderTop: '2px solid lightgrey',
+  },
+  formItem: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  buttons: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  formWrapper: {
+    borderRadius: 6,
+    height: '60vh',
+    width: '95vh',
+    boxShadow: '0 4px 8px 0 rgba(0, 0, 0, 0.4), 0 6px 20px 0 rgba(0, 0, 0, 0.15)',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  checkboxWrap: {
+    border: '1.5px solid lightgrey',
+    borderRadius: '2px',
+  },
+});
+
+export default useStyles;

--- a/client/src/components/Onboarding/Confirm/Confirm.tsx
+++ b/client/src/components/Onboarding/Confirm/Confirm.tsx
@@ -1,33 +1,42 @@
-import { Divider } from '@material-ui/core';
+import { Box, Divider } from '@material-ui/core';
 import { Typography } from '@material-ui/core';
 import { User } from '../../../interface/User';
+import AppLogo from '../../AppLogo';
+import ProgressBar from '../ProgressBar';
+import useStyles from './useStyles';
 
 interface Props {
   loggedInUser: User;
 }
-
 function Confirm({ loggedInUser }: Props): JSX.Element {
+  const classes = useStyles();
   return (
-    <div>
-      <h3>
-        <Typography>
-          Here how CalendApp will work with <span>{loggedInUser.email}</span>
-        </Typography>
-      </h3>
-      <Divider />
-      <div>
-        <Typography>
-          1. We will check <span>{loggedInUser.email}</span> for conflicts
-        </Typography>
-      </div>
-      <Divider />
-      <div>
-        <Typography>
-          2. We will add event to <span>{loggedInUser.email}</span>
-        </Typography>
-      </div>
-      <Divider />
-    </div>
+    <Box mt={5} className={classes.root}>
+      <AppLogo />
+      <Box className={classes.formWrapper}>
+        <ProgressBar progressText={'Your Google Calendar is connected!'} progressValue={50} />
+        <Box className={classes.formItemsWrapper}>
+          <Box mx={6} my={1} className={classes.formItem}>
+            <Typography variant="h6" style={{ marginLeft: '-15px' }}>
+              Here how CalendApp will work with <span>{loggedInUser.email}</span>
+            </Typography>
+          </Box>
+          <Divider />
+          <Box mx={8} mb={1} className={classes.formItem}>
+            <Typography>
+              1. We will check <span>{loggedInUser.email}</span> for conflicts
+            </Typography>
+          </Box>
+          <Divider />
+          <Box mx={8} mb={1} className={classes.formItem}>
+            <Typography>
+              2. We will add event to <span>{loggedInUser.email}</span>
+            </Typography>
+          </Box>
+          <Divider />
+        </Box>
+      </Box>
+    </Box>
   );
 }
 

--- a/client/src/components/Onboarding/Confirm/useStyles.ts
+++ b/client/src/components/Onboarding/Confirm/useStyles.ts
@@ -1,0 +1,42 @@
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles({
+  root: {
+    height: '100%',
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  formItemsWrapper: {
+    width: '100%',
+    height: '100%',
+    borderTop: '2px solid lightgrey',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'space-apart',
+  },
+  formItem: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    height: '55px',
+  },
+  buttons: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  formWrapper: {
+    borderRadius: 6,
+    height: '60vh',
+    width: '80vh',
+    boxShadow: '0 4px 8px 0 rgba(0, 0, 0, 0.4), 0 6px 20px 0 rgba(0, 0, 0, 0.15)',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+});
+
+export default useStyles;

--- a/client/src/components/Onboarding/ProfileSetting/ProfileSetting.tsx
+++ b/client/src/components/Onboarding/ProfileSetting/ProfileSetting.tsx
@@ -1,14 +1,15 @@
-import { TextField, InputAdornment, CircularProgress } from '@material-ui/core';
+import { TextField, InputAdornment, CircularProgress, Box, Button, Grid } from '@material-ui/core';
 import { Autocomplete } from '@material-ui/lab';
-import Grid from '@material-ui/core/Grid';
 import moment from 'moment-timezone';
 import { Formik, FormikHelpers } from 'formik';
 import * as Yup from 'yup';
 import { Typography } from '@material-ui/core';
 import { useHistory } from 'react-router-dom';
 import { useAuth } from '../../../context/useAuthContext';
-import { useEffect } from 'react';
-import { useSocket } from '../../../context/useSocketContext';
+import ProgressBar from '../ProgressBar';
+import useStyles from './useStyles';
+import AppLogo from '../../AppLogo';
+import Confirm from '../Confirm/Confirm';
 
 interface Props {
   handleSubmit: (
@@ -31,13 +32,8 @@ interface Props {
 
 const ProfileSetting = ({ handleSubmit }: Props): JSX.Element => {
   const { loggedInUser } = useAuth();
-  const { initSocket } = useSocket();
-
+  const classes = useStyles();
   const history = useHistory();
-
-  useEffect(() => {
-    initSocket();
-  }, [initSocket]);
 
   if (loggedInUser === undefined) return <CircularProgress />;
   if (!loggedInUser) {
@@ -46,61 +42,71 @@ const ProfileSetting = ({ handleSubmit }: Props): JSX.Element => {
   }
 
   return (
-    <Formik
-      initialValues={{
-        url: '',
-        timezone: '',
-      }}
-      isSubmitting={true}
-      isValidating={true}
-      validationSchema={Yup.object().shape({
-        url: Yup.string().required('Url is required'),
-        timezone: Yup.string().required('Please choose a timezone'), // set up a test
-      })}
-      onSubmit={handleSubmit}
-    >
-      {({ handleSubmit, handleChange, values, touched, errors }) => (
-        <form onSubmit={handleSubmit}>
-          <Grid container spacing={4} alignItems="center">
-            <Grid item xs={4}>
-              <Typography variant="h6">Create Your CalendApp URL: </Typography>
-            </Grid>
-            <Grid item xs={8}>
-              <TextField
-                id="url-field"
-                name="url"
-                variant="outlined"
-                value={values.url}
-                helperText={touched.url ? errors.url : ''}
-                error={touched.url && Boolean(errors.url)}
-                onChange={handleChange}
-                InputProps={{
-                  endAdornment: (
-                    <InputAdornment position="end" component="span">
-                      | {loggedInUser.username}
-                    </InputAdornment>
-                  ),
+    <Grid container spacing={5}>
+      <Grid item xs={12}>
+        <Box mt={6} className={classes.root}>
+          <AppLogo />
+          <Box className={classes.formWrapper}>
+            <ProgressBar progressText={'Welcome to CalendApp'} progressValue={25} />
+            <Box className={classes.formItemsWrapper}>
+              <Formik
+                initialValues={{
+                  url: '',
+                  timezone: '',
                 }}
-              />
-            </Grid>
-            <Grid item xs={4}>
-              <Typography variant="h6">Choose your timezone: </Typography>
-            </Grid>
-            <Grid item xs={8}>
-              <Autocomplete
-                id="timezone-field"
-                value={values.timezone}
-                options={moment.tz.names()}
-                getOptionLabel={(option) => option + ' (' + moment.tz(option).format('ha z') + ')'}
-                getOptionSelected={(option) => values.timezone === option}
-                renderInput={(params) => <TextField {...params} label="Select your timezone" variant="outlined" />}
-                onChange={handleChange}
-              />
-            </Grid>
-          </Grid>
-        </form>
-      )}
-    </Formik>
+                isValidating={true}
+                validationSchema={Yup.object().shape({
+                  url: Yup.string().required('Url is required'),
+                  timezone: Yup.string().required('Please choose a timezone'), // set up a test
+                })}
+                onSubmit={handleSubmit}
+              >
+                {({ handleSubmit, handleChange, values, touched, errors }) => (
+                  <form onSubmit={handleSubmit}>
+                    <Box mt={5} mb={2} mx={10} className={classes.formItem}>
+                      <Typography variant="h6" style={{ marginRight: '8px' }}>
+                        Create Your CalendApp URL:
+                      </Typography>
+                      <TextField
+                        id="url-field"
+                        name="url"
+                        style={{ width: 470 }}
+                        variant="outlined"
+                        value={values.url}
+                        helperText={touched.url ? errors.url : ''}
+                        error={touched.url && Boolean(errors.url)}
+                        onChange={handleChange}
+                        InputProps={{
+                          endAdornment: (
+                            <InputAdornment position="end" component="span">
+                              | {loggedInUser.username}
+                            </InputAdornment>
+                          ),
+                        }}
+                      />
+                    </Box>
+                    <Box mb={2} mx={10} className={classes.formItem}>
+                      <Typography variant="h6">Choose your timezone: </Typography>
+                      <Autocomplete
+                        id="timezone-field"
+                        value={values.timezone}
+                        style={{ width: 270 }}
+                        options={moment.tz.names()}
+                        getOptionLabel={(option) => option + ' (' + moment.tz(option).format('ha z') + ')'}
+                        getOptionSelected={(option) => values.timezone === option}
+                        renderInput={(params) => <TextField {...params} variant="outlined" />}
+                        onChange={handleChange}
+                      />
+                    </Box>
+                  </form>
+                )}
+              </Formik>
+              <Button>{<Confirm loggedInUser={loggedInUser} /> ? 'Contiune' : ''}</Button>
+            </Box>
+          </Box>
+        </Box>
+      </Grid>
+    </Grid>
   );
 };
 

--- a/client/src/components/Onboarding/ProfileSetting/useStyles.ts
+++ b/client/src/components/Onboarding/ProfileSetting/useStyles.ts
@@ -1,0 +1,41 @@
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles({
+  root: {
+    height: '100%',
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  formItemsWrapper: {
+    width: '100%',
+    height: '100%',
+    borderTop: '2px solid lightgrey',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'space-apart',
+  },
+  formItem: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  buttons: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  formWrapper: {
+    borderRadius: 6,
+    height: '60vh',
+    width: '80vh',
+    boxShadow: '0 4px 8px 0 rgba(0, 0, 0, 0.4), 0 6px 20px 0 rgba(0, 0, 0, 0.15)',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+});
+
+export default useStyles;

--- a/client/src/components/Onboarding/ProgressBar.tsx
+++ b/client/src/components/Onboarding/ProgressBar.tsx
@@ -1,0 +1,38 @@
+import { Box, Typography, withStyles } from '@material-ui/core';
+import LinearProgress from '@material-ui/core/LinearProgress';
+import progressStyles from './progressStyles';
+
+interface Props {
+  progressValue: number;
+  progressText: string;
+}
+
+const Progress = withStyles(() => ({
+  root: {
+    height: 10,
+    borderRadius: 5,
+    width: '30vh',
+  },
+  colorPrimary: {
+    backgroundColor: '#f1f3f8',
+  },
+  bar: {
+    backgroundColor: '#f76900',
+    borderRadius: '5px',
+  },
+}))(LinearProgress);
+
+const ProgressBar = ({ progressValue, progressText }: Props): JSX.Element => {
+  const classes = progressStyles();
+
+  return (
+    <Box className={classes.container}>
+      <Typography className={classes.headerItem} variant="h6">
+        {progressText}
+      </Typography>
+      <Progress className={classes.headerItem} variant="determinate" value={progressValue} />
+    </Box>
+  );
+};
+
+export default ProgressBar;

--- a/client/src/components/Onboarding/progressStyles.ts
+++ b/client/src/components/Onboarding/progressStyles.ts
@@ -1,0 +1,15 @@
+import makeStyles from '@material-ui/core/styles/makeStyles';
+
+const progressStyles = makeStyles(() => ({
+  container: {
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'space-evenly',
+    display: 'flex',
+  },
+  headerItem: {
+    margin: '35px 25px',
+  },
+}));
+
+export default progressStyles;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,13 +1,15 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
+    'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+}
+
+.MuiGrid-root.MuiGrid-container {
+  justify-content: space-around;
 }

--- a/client/src/pages/Onboarding/Onboarding.tsx
+++ b/client/src/pages/Onboarding/Onboarding.tsx
@@ -1,8 +1,5 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
-import Stepper from '@material-ui/core/Stepper';
-import Step from '@material-ui/core/Step';
-import StepLabel from '@material-ui/core/StepLabel';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import { FormikHelpers } from 'formik';
@@ -10,13 +7,13 @@ import checkUserUrl from '../../helpers/APICalls/checkUserUrl';
 import Confirm from '../../components/Onboarding/Confirm/Confirm';
 import { useAuth } from '../../context/useAuthContext';
 import ProfileSetting from '../../components/Onboarding/ProfileSetting/ProfileSetting';
-import CircularProgress from '@material-ui/core/CircularProgress';
 import { useHistory } from 'react-router-dom';
-import { useSocket } from '../../context/useSocketContext';
 import Availability from '../../components/Onboarding/Availability/Availability';
 import updateUser from '../../helpers/APICalls/updateUser';
 import checkUserAvailability from '../../helpers/APICalls/checkUserAvailability';
 import updateUserAvailability from '../../helpers/APICalls/updateUserAvailability';
+import Grid from '@material-ui/core/Grid';
+import { Container } from '@material-ui/core';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -34,7 +31,7 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 function getSteps() {
-  return ['Welcome to CalendApp', 'Your Google Calendar is connected', 'Set your availability'];
+  return [25, 50, 100];
 }
 const HandleProfileSubmit = (
   { url, timezone }: { url: string; timezone: string },
@@ -44,7 +41,7 @@ const HandleProfileSubmit = (
     if (data.error) {
       setSubmitting(false);
     } else if (data.success) {
-      updateUser(url, timezone); 
+      updateUser(url, timezone);
     }
   });
 };
@@ -53,29 +50,23 @@ const HandleAvailabilitySubmit = (
   { hours, days }: { hours: string; days: string },
   { setSubmitting }: FormikHelpers<{ hours: string; days: string }>,
 ) => {
-  checkUserAvailability( hours, days ).then((data) => {
+  checkUserAvailability(hours, days).then((data) => {
     if (data.error) {
       setSubmitting(false);
     } else if (data.success) {
       updateUserAvailability(hours, days);
     }
-  })
+  });
 };
 
 function GetStepContent(stepIndex: number) {
   const { loggedInUser } = useAuth();
-  const { initSocket } = useSocket();
-
   const history = useHistory();
 
-  useEffect(() => {
-    initSocket();
-  }, [initSocket]);
-
-  if (loggedInUser === undefined) return <CircularProgress />;
+  if (loggedInUser === undefined) return;
   if (!loggedInUser) {
     history.push('/login');
-    return <CircularProgress />;
+    return;
   }
 
   switch (stepIndex) {
@@ -90,7 +81,7 @@ function GetStepContent(stepIndex: number) {
   }
 }
 
-export default function HorizontalLabelPositionBelowStepper() {
+export default function HorizontalLabelPositionBelowStepper(): JSX.Element {
   const classes = useStyles();
   const [activeStep, setActiveStep] = React.useState(0);
   const steps = getSteps();
@@ -108,34 +99,25 @@ export default function HorizontalLabelPositionBelowStepper() {
   };
 
   return (
-    <div className={classes.root}>
-      <Stepper activeStep={activeStep} alternativeLabel>
-        {steps.map((label) => (
-          <Step key={label}>
-            <StepLabel>{label}</StepLabel>
-          </Step>
-        ))}
-      </Stepper>
-      <div>
-        {activeStep === steps.length ? (
-          <div>
-            <Typography className={classes.instructions}>All steps completed</Typography>
-            <Button onClick={handleReset}>Reset</Button>
-          </div>
-        ) : (
-          <div>
-            <Typography className={classes.instructions}>{GetStepContent(activeStep)}</Typography>
-            <div>
-              <Button disabled={activeStep === 0} onClick={handleBack} className={classes.backButton}>
-                Back
-              </Button>
-              <Button variant="contained" color="primary" onClick={handleNext}>
-                {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
-              </Button>
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
+    <Grid container>
+      {activeStep === steps.length ? (
+        <Grid item>
+          <Typography className={classes.instructions}>All steps completed</Typography>
+          <Button onClick={handleReset}>Reset</Button>
+        </Grid>
+      ) : (
+        <Grid item>
+          <Typography className={classes.instructions}>{GetStepContent(activeStep)}</Typography>
+          <Grid item>
+            <Button disabled={activeStep === 0} onClick={handleBack} className={classes.backButton}>
+              Back
+            </Button>
+            <Button variant="contained" color="primary" onClick={handleNext}>
+              {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
+            </Button>
+          </Grid>
+        </Grid>
+      )}
+    </Grid>
   );
 }

--- a/client/src/pages/Onboarding/useStyles.ts
+++ b/client/src/pages/Onboarding/useStyles.ts
@@ -1,0 +1,15 @@
+import { createStyles, makeStyles, Theme } from '@material-ui/core';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      height: '100%',
+      width: '100%',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+    },
+  }),
+);
+
+export default useStyles;

--- a/server/controllers/onboarding.js
+++ b/server/controllers/onboarding.js
@@ -12,9 +12,7 @@ exports.checkUserUrl = asyncHandler(async (req, res, next) => {
         return res.status(400).json({ msg: 'Url is not valid' });
     }
      
-    const user = new User({
-      url: req.boby.url,
-    });
+    user.url = req.body.url;
 
     await user.save();
     res.json({ user });
@@ -34,10 +32,8 @@ exports.createUserAvailability = asyncHandler(async (req, res) => {
       return res.status(400).json({ msg: 'hours, days, are required fields.'});
   }
    
-  const availability = new Availability({
-    hours: req.body.hours,
-    days: req.body.days
-  });
+  availability.hours = req.body.hours;
+  availability.days = req.body.hours;
 
   await availability.save();
   res.json({ availability });


### PR DESCRIPTION
### What this PR does (required):
- Improvement to FE Onboarding pages

### Screenshots / Videos (required):
- 
<img width="1438" alt="Screen Shot 2021-07-14 at 2 44 23 PM" src="https://user-images.githubusercontent.com/25135432/125688514-674467fb-a3e5-4353-97cb-1f97204f4c88.png">
<img width="1440" alt="Screen Shot 2021-07-14 at 2 44 35 PM" src="https://user-images.githubusercontent.com/25135432/125688528-11d4acf5-34a2-49f8-989b-4c5e272439d8.png">
<img width="1438" alt="Screen Shot 2021-07-14 at 2 44 51 PM" src="https://user-images.githubusercontent.com/25135432/125688534-7fb30a47-ac66-4da8-9dfd-3798a1119c24.png">


### Any information needed to test this feature (required):
- Follow README.md to start app 
- Login with the email: teamtimbitshatchways@gmail.com
- http://localhost:3000/onboarding

### Any issues with the current functionality (optional):
- Besides some needed styling. The button for the Material UI Stepper is out of place. So I'm thinking of ways to get the same functionality from the stepper to a custom button on each page. The custom button should redirect to the appropriate page component. Or taking the Profile Setting component and implementing it with the Onboarding housing component.
